### PR TITLE
arreglado el app.fxml

### DIFF
--- a/src/application/fxml/app/App.fxml
+++ b/src/application/fxml/app/App.fxml
@@ -4,7 +4,6 @@
 <?import java.lang.*?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.layout.AnchorPane?>
-//Mati paga la multa.. firma: Arroyo
 <Pane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="application.controladores.AppControlador">
    <children>
       <TabPane prefHeight="600.0" prefWidth="600.0" tabClosingPolicy="UNAVAILABLE">


### PR DESCRIPTION
El comentario no permitia levantar el fxml desde el scene builder, ya… que los comentarios en fxml tienen el siguiente formato:

```
<!-- comentario-->
```

o puede ser multilinea
        <!-- comentario
        multilinea
        -->
De todos modos no puedo ver si anda bien el app.fxml porque se me buguea el scene builder. Pero lo mas probable es que sea ese el problema.
